### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -12,6 +12,8 @@
 # 2. Start using the action within your workflow
 
 name: Run Datadog Synthetic tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Ku-soluciones/ku-soluciones/security/code-scanning/1](https://github.com/Ku-soluciones/ku-soluciones/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow appears to only check out code and run an external action (Datadog Synthetics), it likely only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` field and before `on:`), which will apply to all jobs in the workflow. No changes to the steps or jobs are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
